### PR TITLE
Ignore CNAME when building Jekyll site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ exclude:
 - ".gitignore"
 - ".travis.yml"
 - todo.txt
+- CNAME
 - resources
 - Gemfile
 - Gemfile.lock


### PR DESCRIPTION
This adds the `CNAME` file to the exclusion list during the `jekyll build` process.