### PR TITLE
make the SAORM apply Information Management and Access to records

### DIFF
--- a/pages/policy.md
+++ b/pages/policy.md
@@ -212,7 +212,7 @@ Agencies shall:
 
 2) Ensure that records management programs provide adequate and proper documentation of agency activities.
 
-3) Ensure the ability to access, retrieve, and manage records throughout their life cycle regardless of form or medium.
+3) Consider records as an information asset and ensure the ability to access, retrieve, and manage records throughout their life cycle regardless of form or medium in accordance with section (h), Information Management and Access.
 
 4) Establish and obtain the approval of the Archivist of the United States for retention schedules for Federal records in a timely fashion.
 


### PR DESCRIPTION
Make it explicit that agency records managed by the SAORM are information resources that should be treated as under (h) Information Management and Access
