### PR TITLE
expand on open data aspects of "appropriately use disseminated information"

### DIFF
--- a/pages/policy.md
+++ b/pages/policy.md
@@ -252,7 +252,7 @@ Agencies shall:
   
   b) Avoid establishing, or permitting others to establish on their behalf, exclusive, restricted, or other distribution arrangements that interfere with allowing the agency to disseminate its information on a timely and equitable basis. In certain cases, it may be appropriate to engage in time-limited restrictions or exclusively in cases where the agency, due to resource constraints, would otherwise be unable to provide the information to the public on its own;
   
-  c) Avoid establishing unnecessary restrictions on the reuse, resale, or re-dissemination of Federal information by the public, including charging of fees or royalties, requirements of attribution or registration, and requiring the agreement to a contract in exchange for access to Federal information resources;<sup id="fnr14"><a href="#fn14">14</a></sup> 
+  c) Avoid establishing unnecessary restrictions on the reuse, resale, or re-dissemination of Federal information by the public, including charging of fees or royalties, requirements of attribution or registration, and requiring the agreement to a license or contract in exchange for access to Federal information resources;<sup id="fnr14"><a href="#fn14">14</a></sup> 
   
   d) Recovering only the cost of dissemination if fee and user charges are necessary. They must exclude from calculation the costs associated with original collection and processing of the information. Exceptions to this policy are:
   i. Where statutory requirements are at variance with the policy;

--- a/pages/policy.md
+++ b/pages/policy.md
@@ -242,17 +242,17 @@ Agencies shall:
 
 3) Agencies shall ensure that the public can appropriately discover, and provide feedback about disseminated information and unreleased information by:
 
-  a) Ensuring that data, wherever possible and legally permissible, are released to the public in ways that make the data easy to find, accessible, and usable; and
+  a) Ensuring that data, wherever possible and legally permissible, are released to the public in ways that make the data easy to find through commonly used web search applications, accessible, and usable; and
   
   b) Developing other aids as necessary to assist the public in locating agency information including catalogs and directories, site maps, search functions, and other means.
 
 4) Agencies shall ensure that the public can appropriately use disseminated information by:
 
-  a) Publishing information online in a, machine-readable open format that can be retrieved, downloaded, indexed, and searched by commonly used web search applications and is public, accessible, described, reusable, complete, timely. This includes providing such information in a format(s) accessible to employees and members of the public with disabilities.<sup id="fnr13"><a href="#fn13">13</a></sup> 
+  a) Publishing information online in a manner that promotes analysis and reuse, meaning the information resource is public and available for download, accessible, in an appropriate machine-readable open format, described, complete, granular, and timely. This includes providing such information in a format(s) accessible to employees and members of the public with disabilities.<sup id="fnr13"><a href="#fn13">13</a></sup> 
   
   b) Avoid establishing, or permitting others to establish on their behalf, exclusive, restricted, or other distribution arrangements that interfere with allowing the agency to disseminate its information on a timely and equitable basis. In certain cases, it may be appropriate to engage in time-limited restrictions or exclusively in cases where the agency, due to resource constraints, would otherwise be unable to provide the information to the public on its own;
   
-  c) Avoid establishing unnecessary restrictions, including charging of fees or royalties, on the reuse, resale, or re-dissemination of Federal information by the public;<sup id="fnr14"><a href="#fn14">14</a></sup> 
+  c) Avoid establishing unnecessary restrictions on the reuse, resale, or re-dissemination of Federal information by the public, including charging of fees or royalties, requirements of attribution or registration, and requiring the agreement to a contract in exchange for access to Federal information resources;<sup id="fnr14"><a href="#fn14">14</a></sup> 
   
   d) Recovering only the cost of dissemination if fee and user charges are necessary. They must exclude from calculation the costs associated with original collection and processing of the information. Exceptions to this policy are:
   i. Where statutory requirements are at variance with the policy;

--- a/pages/policy.md
+++ b/pages/policy.md
@@ -248,7 +248,7 @@ Agencies shall:
 
 4) Agencies shall ensure that the public can appropriately use disseminated information by:
 
-  a) Publishing information online in a manner that promotes analysis and reuse, meaning the information resource is public and available for download, accessible, in an appropriate machine-readable open format, described, complete, granular, and timely. This includes providing such information in a format(s) accessible to employees and members of the public with disabilities.<sup id="fnr13"><a href="#fn13">13</a></sup> 
+  a) Publishing information online in a manner that promotes analysis and reuse for the widest possible range of purposes, meaning the information resource is public and available for download in bulk, accessible (as defined in this document), in an appropriate machine-readable open format, described, complete, granular, and timely. This includes providing such information in a format(s) accessible to employees and members of the public with disabilities.<sup id="fnr13"><a href="#fn13">13</a></sup> 
   
   b) Avoid establishing, or permitting others to establish on their behalf, exclusive, restricted, or other distribution arrangements that interfere with allowing the agency to disseminate its information on a timely and equitable basis. In certain cases, it may be appropriate to engage in time-limited restrictions or exclusively in cases where the agency, due to resource constraints, would otherwise be unable to provide the information to the public on its own;
   


### PR DESCRIPTION
This expands on the open data aspects of the policy statement for "appropriately use disseminated information". The specific changes are:

I moved "commonly used web search applications" out of the part about the data up to the section on discoverability.

I removed "retrieved", "indexed", and "searched", because these seem redundant with discoverability or were ambiguous if the purpose was discoverability or if the data itself should be searchable (like a searchable PDF).

I added "analysis and reuse" to the list of things to do, since that's a phrase that I think best captures the spirit of open data.

I added "appropriate" before machine-readable format, i.e. choose the right format for the data, not any machine-readable format. PDFs are machine-readable but often not appropriate.

I added "granular", to get in the idea of "primary" from the 8 Principles of Open Gov Data

"accessible" is defined in Definitions to mean section 508 compliance. This differs from how the term is used in the open data community, where it also compasses variously: available, usable for a wide range of purposes, published in bulk, documented, etc. So I'm clarifying in this PR that accessible is used here as it is defined in Definitions, and I'm explicitly adding "widest possible range of purposes" and "in bulk" to cover the other aspects of the open-data meaning of accessible. (Documented is already covered by "described.")

I added "requirements of attribution or registration, and requiring the agreement to a license or contract in exchange for access to Federal information resources" to the later part on requirements to avoid.
