### PR TITLE
remove redundant definition of "open data"

### DIFF
--- a/pages/definitions.md
+++ b/pages/definitions.md
@@ -75,7 +75,7 @@ ee. 'Major information technology investment' means an investment that requires 
 
 ff. 'National security system' means any information system (including any telecommunications system) used or operated by an agency or by a contractor of an agency, or other organization on behalf of an agency: the function, operation, or use of which involves intelligence activities; involves cryptologic activities related to national security; involves command and control of military forces; involves equipment that is an integral part of a weapon or weapons system; or is critical to the direct fulfillment of military or intelligence missions (excluding a system that is to be used for routine administrative and business applications, for example, payroll, finance, logistics, and personnel management applications); or is protected at all times by procedures established for information that have been specifically authorized under criteria established by an Executive Order or an Act of Congress to be kept classified in the interest of national defense or foreign policy (44 U.S.C. § 3542).
 
-gg. 'Open data' means publicly available data structured in a way that enables the data to be fully discoverable and usable by end users. Generally, open data are public, accessible, machine-readable, described, reusable, complete, timely, and managed in manners consistent with OMB guidance defining these terms, including relevant privacy, security, and other valid access, use, and dissemination restrictions.
+gg. [removed]
 
 hh. 'Personally identifiable information' (PII) means information that can be used to distinguish or trace an individual's identity, either alone or when combined with other information that is linked or linkable to a specific individual.
 

--- a/pages/policy.md
+++ b/pages/policy.md
@@ -236,7 +236,7 @@ Agencies shall:
  
   i. Creating or collecting all new information electronically by default, in machine-readable open formats, using relevant data standards, that upon creation includes standard extensible metadata identifying any restrictions to access, use, and dissemination in accordance with OMB guidance; and
  
-  ii. For all instances where new Federal information creation or collection does not fall squarely within the public domain as U.S. government work, agencies shall include appropriate provisions in contracts to meet objectives of open data while recognizing that contractors may have proprietary interests in such information, and that protection of such information may be necessary to encourage qualified contractors to participate in and apply innovative concepts to government programs.
+  ii. For all instances where new Federal information creation or collection does not fall squarely within the public domain as U.S. government work, agencies shall include appropriate provisions in contracts to meet the objectives of OMB guidance with respect to maximizing public access and use (see 4, below) while recognizing that contractors may have proprietary interests in such information, and that protection of such information may be necessary to encourage qualified contractors to participate in and apply innovative concepts to government programs.
   
   b) Ensure that the public has timely and equitable online access to the agency's public information using a manner that is informed directly by public engagement and balanced against the costs of dissemination or accessibility improvements and demonstrate usefulness of the information.
 


### PR DESCRIPTION
The term "open data" is defined in Definitions but is used only once in the paragraph on giving away data rights in contracted work. That paragraph doesn't benefit much from referencing open data as a special term.

The definition paragraph is also redundant with the same terminology used in the policy page, where it is clearer and more expansive. So in the interests of removing redundancy, I'm suggesting removing the term "open data" from the entire document and just spelling out the goals and requirements once.

Then to fix the one reference to "open data", I'm replacing it with "the objectives of OMB guidance with respect to maximizing public access and use (see 4, below)".

This PR should be considered together with #34, where I expand on those objectives.
