### PR TITLE
avoid implying that any contract warrants IP protections for the contractor

### DIFF
--- a/pages/policy.md
+++ b/pages/policy.md
@@ -236,7 +236,7 @@ Agencies shall:
  
   i. Creating or collecting all new information electronically by default, in machine-readable open formats, using relevant data standards, that upon creation includes standard extensible metadata identifying any restrictions to access, use, and dissemination in accordance with OMB guidance; and
  
-  ii. For all instances where new Federal information creation or collection does not fall squarely within the public domain as U.S. government work, agencies shall include appropriate provisions in contracts to meet objectives of open data while recognizing that contractors may have proprietary interests in such information, and that protection of such information may be necessary to encourage qualified contractors to participate in and apply innovative concepts to government programs.
+  ii. For all instances where new Federal information creation or collection does not fall squarely within the public domain as U.S. government work, agencies shall include appropriate provisions in contracts to meet objectives of open data. Recognizing that contractors may have proprietary interests in such information, protection of such information may be necessary to encourage qualified contractors to participate in and apply innovative concepts to government programs.
   
   b) Ensure that the public has timely and equitable online access to the agency's public information using a manner that is informed directly by public engagement and balanced against the costs of dissemination or accessibility improvements and demonstrate usefulness of the information.
 


### PR DESCRIPTION
The paragraph I'm modifying here was an adaptation from the M-13-13 memo, which tried to direct agencies to make open data.... but without directing them to _always_ make open data because sometimes it's OK to give the contractor the IP, trading IP rights for dollars on the contract, effectively.

OK. Fine. But let's be clearer about it.

As written, the text sets up a tension between open data and "proprietary interests." That's not the right tension. What does OMB care about proprietary interests, really? It should be a tension between open data and "encourag[ing] qualified contractors to participate." 

I've made a minimal change that I think gets at this ---- simply splitting the sentence into two:

> For all instances where new Federal information creation or collection does not fall squarely within the public domain as U.S. government work, agencies shall include appropriate provisions in contracts to meet objectives of open data. [SENTENCE BREAK HERE] Recognizing that contractors may have proprietary interests in such information, protection of such information may be necessary to encourage qualified contractors to participate in and apply innovative concepts to government programs.

This PR overlaps with #35, where I've replaced "open data" in this paragraph with a reference to the guidance in subsequent paragraphs, and #34, where I've added to that guidance more explicit language about licenses and contracts. The three PRs go together.
