### PR TITLE
Update policy.md

### DIFF
--- a/pages/policy.md
+++ b/pages/policy.md
@@ -236,9 +236,9 @@ Agencies shall:
  
   i. Creating or collecting all new information electronically by default, in machine-readable open formats, using relevant data standards, that upon creation includes standard extensible metadata identifying any restrictions to access, use, and dissemination in accordance with OMB guidance; and
  
-  ii. For all instances where new Federal information creation or collection does not fall squarely within the public domain as U.S. government work, agencies shall include appropriate provisions in contracts to meet objectives of open data while recognizing that contractors may have proprietary interests in such information, and that protection of such information may be necessary to encourage qualified contractors to participate in and apply innovative concepts to government programs.
+  ii. For all instances where new Federal information creation or collection does not fall squarely within the public domain as U.S. government work, agencies shall include appropriate provisions in contracts to best meet the objectives of open data.
   
-  b) Ensure that the public has timely and equitable online access to the agency's public information using a manner that is informed directly by public engagement and balanced against the costs of dissemination or accessibility improvements and demonstrate usefulness of the information.
+  b) Ensure that the public has timely and equitable online access to the agency's public information using a manner that is informed directly by public engagement and considers costs.
 
 3) Agencies shall ensure that the public can appropriately discover, and provide feedback about disseminated information and unreleased information by:
 


### PR DESCRIPTION
Two fairly small changes to provisions under Information Management and Access.  I cut the discussion about possible proprietary and information protection interests of contractors because it seemed unnecessary to try listing out the factors agencies may have to consider when trying to meet open data objectives for data that doesn't fall squarely in the public domain.  These may be some of the concerns now but in 5 years other factors may be more prominent.  Instead I think it makes more sense to keep it simple.  The provision already says "appropriate provisions" which gives agencies enough leeway.  
On the second provision, I again thought it was unnecessary to try to list where cost concerns derived from.  The original draft highlighted cost of dissemination and accessibility improvements.  Again these may be the source of concerns now but given that we are drafting for the next decade or two, it makes more sens to simply say "considers costs." 
The final words of the provision were confusing to me "and demonstrate usefulness of the information"  I couldn't tell if this was the third thing being listed that online access had to meet -- informed by the public, considers costs, and demonstrates the usefulness of the info.  Or if it was another aspect that access needed to be balanced against - costs and the demonstrated usefulness of info. The first approach would probably be acceptable but didn't seem vital and the second possibility was very troubling.  So I suggested cutting it.  If there is a good reason to keep it, it should be made much more clear.
