### PR TITLE
Modify and clarify language

### DIFF
--- a/pages/policy.md
+++ b/pages/policy.md
@@ -238,7 +238,7 @@ Agencies shall:
  
   ii. For all instances where new Federal information creation or collection does not fall squarely within the public domain as U.S. government work, agencies shall include appropriate provisions in contracts to meet objectives of open data while recognizing that contractors may have proprietary interests in such information, and that protection of such information may be necessary to encourage qualified contractors to participate in and apply innovative concepts to government programs.
   
-  b) Ensure that the public has timely and equitable online access to the agency's public information using a manner that is informed directly by public engagement and balanced against the costs of dissemination or accessibility improvements and demonstrate usefulness of the information.
+  b) Ensure that the public has timely and equitable online access to the agency's public information using a manner that is informed directly by public engagement and balanced against the costs of dissemination or accessibility improvements.
 
 3) Agencies shall ensure that the public can appropriately discover, and provide feedback about disseminated information and unreleased information by:
 


### PR DESCRIPTION
Lines 659-62 (in PDF): ”b) Ensure that the public has timely and equitable online access to the agency’s public information using a manner that is informed directly by public engagement and balanced against the costs of dissemination or accessibility improvements and demonstrate usefulness of the information.”

This language requires modification. Once federal information is digital, the costs of dissemination are minimal, and accessibility improvements should be taken into consideration as a system or application is procured or developed. Clarification is also needed as to whether “accessibility” here is intended to refer to Sec. 508 requirements.  The language after ‘improvements’ should be struck; it is a remnant of arguments about whether the government should be in the role of providing information to the public – which has been settled.
