### PR TITLE
Add language on format

### DIFF
--- a/pages/policy.md
+++ b/pages/policy.md
@@ -263,7 +263,7 @@ Agencies shall:
   
   iv. Where the Director of OMB determines an exception is warranted.
 
-  e) Ensuring that government publications are made available to depository libraries through the Government Publishing Office.<sup id="fnr15"><a href="#fn15">15</a></sup> 
+  e) Ensuring that government publications are made available to depository libraries through the Government Publishing Office regardless of format.<sup id="fnr15"><a href="#fn15">15</a></sup> 
   
   f) Taking advantage of all dissemination channels, including Federal, State, local, tribal, territorial governments, libraries, nonprofit, and private sector entities, in discharging agency information dissemination responsibilities.
 


### PR DESCRIPTION
Lines 696-697 (in PDF): Add “regardless of format.” This would restore but update the language from the earlier circular which, in 6(h) required agencies to “provide electronic information dissemination products to the Government Printing Office for distribution to depository libraries.”
